### PR TITLE
chore(package): add typings field to resolve ESM imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "keywords": [],
   "main": "dist/index.js",
   "module": "dist/index.mjs",
+  "typings": "dist/index.d.ts",
   "exports": {
     ".": {
       "require": "./dist/index.js",


### PR DESCRIPTION
Pure ESM projects need a `typings` field to properly fetch the types. Since we're moving to that internally this breaks a bit.